### PR TITLE
Allow placing a batch on a chain

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -50,7 +50,7 @@ class ChainedBatch implements ShouldQueue
 
     protected function hijackChain(PendingBatch $batch)
     {
-        if (property_exists($this, 'chained') && ! empty($this->chained)) {
+        if (! empty($this->chained)) {
             $next = unserialize(array_shift($this->chained));
             $next->chained = $this->chained;
 

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -12,7 +12,7 @@ class ChainedBatch implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable;
 
-    public array|Collection $jobs;
+    public Collection $jobs;
 
     public array $options;
 

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Bus;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+
+class ChainedBatch implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable;
+
+    public array|Collection $jobs;
+
+    public array $options;
+
+    public string $name;
+
+    public function __construct(PendingBatch $batch)
+    {
+        $this->jobs = $batch->jobs;
+        $this->options = $batch->options;
+        $this->name = $batch->name;
+    }
+
+    public function handle(Container $container)
+    {
+        $batch = new PendingBatch($container, $this->jobs);
+        $batch->name = $this->name;
+        $batch->options = $this->options;
+
+        $this->hijackChain($batch);
+
+        if ($this->queue) {
+            $batch->onQueue($this->queue);
+        }
+
+        if ($this->connection) {
+            $batch->onConnection($this->connection);
+        }
+
+        foreach ($this->chainCatchCallbacks as $cb) {
+            $batch->catch($cb);
+        }
+
+        $batch->dispatch();
+    }
+
+    protected function hijackChain(PendingBatch $batch)
+    {
+        if (property_exists($this, 'chained') && ! empty($this->chained)) {
+            $next = unserialize(array_shift($this->chained));
+            $next->chained = $this->chained;
+
+            $next->onConnection($next->connection ?: $this->chainConnection);
+            $next->onQueue($next->queue ?: $this->chainQueue);
+
+            $next->chainConnection = $this->chainConnection;
+            $next->chainQueue = $this->chainQueue;
+            $next->chainCatchCallbacks = $this->chainCatchCallbacks;
+
+            $batch->then(fn () => dispatch($next));
+
+            $this->chained = [];
+        }
+    }
+}

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -31,7 +31,7 @@ class ChainedBatch implements ShouldQueue
         $batch->name = $this->name;
         $batch->options = $this->options;
 
-        $this->hijackChain($batch);
+        $this->moveChainToEndOfBatch($batch);
 
         if ($this->queue) {
             $batch->onQueue($this->queue);
@@ -48,7 +48,7 @@ class ChainedBatch implements ShouldQueue
         $batch->dispatch();
     }
 
-    protected function hijackChain(PendingBatch $batch)
+    protected function moveChainToEndOfBatch(PendingBatch $batch)
     {
         if (! empty($this->chained)) {
             $next = unserialize(array_shift($this->chained));
@@ -80,8 +80,8 @@ class ChainedBatch implements ShouldQueue
             if ($job instanceof PendingBatch) {
                 $jobs[$k] = new ChainedBatch($job);
             }
-        }
 
+}
         return $jobs;
     }
 }

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -163,6 +163,7 @@ class Dispatcher implements QueueingDispatcher
     public function chain($jobs)
     {
         $jobs = Collection::wrap($jobs);
+        $jobs = ChainedBatch::prepareNestedBatches($jobs);
 
         return new PendingChain($jobs->shift(), $jobs->toArray());
     }

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -54,8 +54,6 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Create a new command dispatcher instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @param  \Closure|null  $queueResolver
      * @return void
      */
     public function __construct(Container $container, Closure $queueResolver = null)
@@ -135,7 +133,6 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Attempt to find the batch with the given ID.
      *
-     * @param  string  $batchId
      * @return \Illuminate\Bus\Batch|null
      */
     public function findBatch(string $batchId)
@@ -163,6 +160,14 @@ class Dispatcher implements QueueingDispatcher
     public function chain($jobs)
     {
         $jobs = Collection::wrap($jobs);
+
+        $jobs = $jobs->map(function ($job) {
+            if ($job instanceof PendingBatch) {
+                return new ChainedBatch($job);
+            }
+
+            return $job;
+        });
 
         return new PendingChain($jobs->shift(), $jobs->toArray());
     }
@@ -270,7 +275,6 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Set the pipes through which commands should be piped before dispatching.
      *
-     * @param  array  $pipes
      * @return $this
      */
     public function pipeThrough(array $pipes)
@@ -283,7 +287,6 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Map a command to a handler.
      *
-     * @param  array  $map
      * @return $this
      */
     public function map(array $map)

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -54,6 +54,8 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Create a new command dispatcher instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Closure|null  $queueResolver
      * @return void
      */
     public function __construct(Container $container, Closure $queueResolver = null)
@@ -133,6 +135,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Attempt to find the batch with the given ID.
      *
+     * @param  string  $batchId
      * @return \Illuminate\Bus\Batch|null
      */
     public function findBatch(string $batchId)
@@ -160,7 +163,6 @@ class Dispatcher implements QueueingDispatcher
     public function chain($jobs)
     {
         $jobs = Collection::wrap($jobs);
-        $jobs = ChainedBatch::prepareNestedBatches($jobs);
 
         return new PendingChain($jobs->shift(), $jobs->toArray());
     }
@@ -268,6 +270,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Set the pipes through which commands should be piped before dispatching.
      *
+     * @param  array  $pipes
      * @return $this
      */
     public function pipeThrough(array $pipes)
@@ -280,6 +283,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Map a command to a handler.
      *
+     * @param  array  $map
      * @return $this
      */
     public function map(array $map)

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -160,14 +160,7 @@ class Dispatcher implements QueueingDispatcher
     public function chain($jobs)
     {
         $jobs = Collection::wrap($jobs);
-
-        $jobs = $jobs->map(function ($job) {
-            if ($job instanceof PendingBatch) {
-                return new ChainedBatch($job);
-            }
-
-            return $job;
-        });
+        $jobs = ChainedBatch::prepareNestedBatches($jobs);
 
         return new PendingChain($jobs->shift(), $jobs->toArray());
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# Context

## Where do we use this:
This is a use case we encounter in a couple places at Square where we have a serial process of jobs that need to be handled and one or more of the steps either should be worked on in parallel or are of unknown length when initially triggering the workflow and will create additional jobs, but we need to know when this is finished to ensure we keep the chain going.

## Example workflow
An example could be onboarding users from a different, separate system. The steps to do so could be the following:

```
1. Create user account and base metadata
2. Pull user account additional information / status from remote systems
3. Download e-commerce catalog from service A
    ^ many paginated requests, good use case for Batch.
4. Notify service B or current setup status
5. Precompute indexing data based on data downloaded in step 3
    ^ also a perfect candidate for batching
6. Notify user of account readiness
```

## How it would look like with Laravel today
There is currently not a great way to express something like this in Laravel. The closest we can get to is something like:

```php
// Start with a chain of multiple steps
Bus::chain([
    new AccountInitialize(),
    new GetAccountMetadata(),
    /**
     * This step would make paginated requests to a remote service.
     * Each job would query 1 page and then if given a cursor to a next page,
     * dispatch a job to do the same thing on that next page.
     * 
     * So we're creating a job to start a batch since a batch can dynamically
     * receive new jobs and still track the completion of the entire process. 
     */
    new StartDownloadEcommerceData(), 
])->dispatch();

class StartDownloadEcommerceData extends BaseJob
{
    public function handle()
    {
        Bus::batch([new DownloadEcommerceDataPage(page: 0)]) // if there are more pages, the first job would add another to the batch
            ->then(function () {
                Bus::chain([
                    new NotifyServiceBStatusUpdate(),
                    new StartPrecomputingDownloadedData(),
                ])->dispatch();
            });
    }
}

class StartPrecomputingDownloadedData extends BaseJob
{
    public function handle()
    {
        $b = Bus::batch();
        foreach ($data as $d) {
            $b->add(new PrecomputeData($d));
        }

        $b->then(function () {
            dispatch(new NotifyUserAccountReady());
        });

        $b->dispatch();
    }
}
```
# Proposal

The previous example takes away a lot of clarity from the workflow with different pieces being started / kicked off in multiple places in code. What we would prefer instead is to write something like:

```php
Bus::chain([
    new AccountInitialize(),
    new GetAccountMetadata(),
    Bus::batch([new DownloadEcommerceDataPage(page: 0)]), // if there are more pages, the first job would add another to the batch
    new NotifyServiceBStatusUpdate(),
    Bus::batch([new StartPrecomputingDownloadedData()]), // first job will load the data and add 1 job / item to the batch
    new NotifyUserAccountReady(),
])->dispatch();
```

This allows us to see in one single place all the actions that will happen as part of the entire workflow. That also makes maintenance much simpler as we don't need to track across many files the downstream dependencies and effects of a given job. Everything is laid out clearly in one central place.

# The PR

This PR implements a way to achieve the proposed syntax above. It also allows nesting `chains` and `batches` to even deeper levels if needed.

Would love to see if this would make a good addition to Laravel. This is definitely something we'll be using on our side.